### PR TITLE
test(ci): add live Tailscale E2E workflow

### DIFF
--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -1,0 +1,135 @@
+name: live-e2e
+
+on:
+  workflow_dispatch:
+    inputs:
+      run-linux:
+        description: Run the Linux live E2E lane
+        required: false
+        default: true
+        type: boolean
+      run-windows:
+        description: Run the Windows live E2E lane
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: live-e2e
+  cancel-in-progress: false
+
+jobs:
+  linux-live-e2e:
+    if: ${{ github.event.inputs.run-linux != 'false' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.6"
+
+      - name: Build Linux CLI binary
+        run: |
+          mkdir -p dist
+          go build -o dist/tailstick-linux-cli ./cmd/tailstick-linux-cli
+
+      - name: Build isolated Linux test image
+        run: docker build -f tests/live/linux-live-e2e.dockerfile -t tailstick-live-e2e .
+
+      - name: Start isolated Linux systemd container
+        run: |
+          docker run --detach \
+            --name tailstick-live-e2e \
+            --privileged \
+            --cgroupns=host \
+            --tmpfs /run \
+            --tmpfs /run/lock \
+            --volume /sys/fs/cgroup:/sys/fs/cgroup:rw \
+            --volume "${{ github.workspace }}:/src" \
+            --workdir /src \
+            tailstick-live-e2e
+
+      - name: Wait for Linux container init
+        run: |
+          for _ in $(seq 1 30); do
+            if docker exec tailstick-live-e2e bash -lc 'test -d /run/systemd/system'; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker exec tailstick-live-e2e bash -lc 'ls -la /run || true'
+          exit 1
+
+      - name: Run Linux live E2E
+        env:
+          TAILSTICK_AUTH_KEY: ${{ secrets.TAILSTICK_LIVE_E2E_AUTH_KEY }}
+          TAILSTICK_API_KEY: ${{ secrets.TAILSTICK_LIVE_E2E_API_KEY }}
+          TAILSTICK_OPERATOR_PASSWORD: ${{ secrets.TAILSTICK_LIVE_E2E_OPERATOR_PASSWORD }}
+          TAILSTICK_BIN: /src/dist/tailstick-linux-cli
+        run: |
+          docker exec \
+            -e TAILSTICK_AUTH_KEY \
+            -e TAILSTICK_API_KEY \
+            -e TAILSTICK_OPERATOR_PASSWORD \
+            -e TAILSTICK_BIN \
+            tailstick-live-e2e \
+            bash /src/tests/live/linux-live-e2e.sh
+
+      - name: Dump Linux live E2E logs on failure
+        if: failure()
+        run: |
+          docker exec tailstick-live-e2e bash -lc 'journalctl --no-pager || true'
+          docker exec tailstick-live-e2e bash -lc 'cat /tmp/tailstick-live-e2e/tailscaled.log || true'
+          docker exec tailstick-live-e2e bash -lc 'cat /tmp/tailstick-live-e2e/tailstick.log || true'
+          docker exec tailstick-live-e2e bash -lc 'cat /tmp/tailstick-live-e2e/state.json || true'
+
+      - name: Stop isolated Linux container
+        if: always()
+        run: docker rm -f tailstick-live-e2e || true
+
+  windows-live-e2e:
+    if: ${{ github.event.inputs.run-windows != 'false' }}
+    runs-on: windows-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.6"
+
+      - name: Build Windows CLI binary
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          go build -o dist/tailstick-windows-cli.exe ./cmd/tailstick-windows-cli
+
+      - name: Install Tailscale
+        shell: pwsh
+        run: |
+          winget install -e --id Tailscale.Tailscale --accept-package-agreements --accept-source-agreements
+          $tailscalePath = "C:\Program Files\Tailscale"
+          if (-not (Test-Path (Join-Path $tailscalePath "tailscale.exe"))) {
+            throw "tailscale.exe not found after install"
+          }
+          Add-Content -Path $env:GITHUB_PATH -Value $tailscalePath
+
+      - name: Run Windows live E2E
+        shell: pwsh
+        env:
+          TAILSTICK_EPHEMERAL_AUTH_KEY: ${{ secrets.TAILSTICK_LIVE_E2E_EPHEMERAL_AUTH_KEY }}
+          TAILSTICK_API_KEY: ${{ secrets.TAILSTICK_LIVE_E2E_API_KEY }}
+          TAILSTICK_OPERATOR_PASSWORD: ${{ secrets.TAILSTICK_LIVE_E2E_OPERATOR_PASSWORD }}
+        run: ./tests/live/windows-live-e2e.ps1
+
+      - name: Dump Windows live E2E logs on failure
+        if: failure()
+        shell: pwsh
+        run: |
+          $workDir = Join-Path $env:TEMP "tailstick-live-e2e"
+          Get-Content -Path (Join-Path $workDir "tailstick.log") -ErrorAction SilentlyContinue
+          Get-Content -Path (Join-Path $workDir "state.json") -ErrorAction SilentlyContinue

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,6 +8,36 @@
 2. Linux sandbox E2E in Docker (`ubuntu:24.04`)
 3. Windows VM smoke on `windows-latest`
 
+## Live E2E
+
+File: `.github/workflows/live-e2e.yml`
+
+This workflow is manual by design (`workflow_dispatch`) and uses real Tailscale credentials stored as GitHub Actions secrets:
+
+- `TAILSTICK_LIVE_E2E_AUTH_KEY`
+- `TAILSTICK_LIVE_E2E_EPHEMERAL_AUTH_KEY`
+- `TAILSTICK_LIVE_E2E_API_KEY`
+- `TAILSTICK_LIVE_E2E_OPERATOR_PASSWORD`
+
+It is intentionally separate from the default CI matrix because it creates real tailnet devices and performs real cleanup/delete operations.
+
+### Linux Live E2E
+
+- Runs inside a privileged Ubuntu 24.04 systemd container built from `tests/live/linux-live-e2e.dockerfile`
+- Installs the real Tailscale package in the container
+- Starts an isolated `tailscaled` instance with its own socket and state file
+- Executes the real Linux CLI binary against the live tailnet
+- Verifies real device creation, cleanup, API deletion, and agent self-removal
+
+### Windows Live E2E
+
+- Runs on GitHub-hosted `windows-latest`
+- Installs the real Tailscale Windows client on the ephemeral runner
+- Executes the real Windows CLI binary against the live tailnet
+- Verifies live enrollment, scheduled task creation, cleanup, API deletion, and agent self-removal
+
+These live lanes are isolated from the developer workstation running Codex. The Linux lane is additionally isolated from the host runner via a dedicated container and `tailscaled` socket/state.
+
 ## Linux Sandbox E2E
 
 File: `tests/sandbox/linux-sandbox-e2e.sh`

--- a/tests/live/linux-live-e2e.dockerfile
+++ b/tests/live/linux-live-e2e.dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:24.04
+
+ENV container=docker
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        dbus \
+        iproute2 \
+        jq \
+        systemd \
+        systemd-sysv \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+STOPSIGNAL SIGRTMIN+3
+
+CMD ["/sbin/init"]

--- a/tests/live/linux-live-e2e.sh
+++ b/tests/live/linux-live-e2e.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_env() {
+  local name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "missing required env: $name" >&2
+    exit 1
+  fi
+}
+
+wait_for_device_gone() {
+  local device_id="$1"
+  local body_file="$WORKDIR/device-api-response.json"
+  local status_code
+
+  for _ in $(seq 1 30); do
+    status_code="$(curl -sS -u "${TAILSTICK_API_KEY}:" -o "$body_file" -w '%{http_code}' "https://api.tailscale.com/api/v2/device/${device_id}" || true)"
+    if [ "$status_code" = "404" ]; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "device ${device_id} still exists after cleanup" >&2
+  cat "$body_file" >&2 || true
+  return 1
+}
+
+require_env TAILSTICK_AUTH_KEY
+require_env TAILSTICK_API_KEY
+require_env TAILSTICK_OPERATOR_PASSWORD
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "linux live E2E must run as root inside the container" >&2
+  exit 1
+fi
+
+TAILSTICK_BIN="${TAILSTICK_BIN:-/src/dist/tailstick-linux-cli}"
+WORKDIR="/tmp/tailstick-live-e2e"
+CONFIG_PATH="$WORKDIR/tailstick.config.json"
+STATE_PATH="$WORKDIR/state.json"
+LOG_PATH="$WORKDIR/tailstick.log"
+AUDIT_PATH="$WORKDIR/audit.ndjson"
+WRAPPER_DIR="$WORKDIR/bin"
+TS_SOCKET="$WORKDIR/tailscaled.sock"
+TS_STATE="$WORKDIR/tailscaled.state"
+TS_LOG="$WORKDIR/tailscaled.log"
+LEASE_ID=""
+DEVICE_ID=""
+TAILSCALED_PID=""
+
+cleanup() {
+  set +e
+
+  if [ -n "$DEVICE_ID" ]; then
+    curl -sS -u "${TAILSTICK_API_KEY}:" -X DELETE "https://api.tailscale.com/api/v2/device/${DEVICE_ID}" >/dev/null 2>&1 || true
+  fi
+
+  if [ -n "$TAILSCALED_PID" ]; then
+    kill "$TAILSCALED_PID" >/dev/null 2>&1 || true
+    wait "$TAILSCALED_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "$WORKDIR" "$WRAPPER_DIR"
+
+curl -fsSL https://tailscale.com/install.sh | sh
+
+REAL_TAILSCALE="$(command -v tailscale)"
+REAL_TAILSCALED="$(command -v tailscaled)"
+
+cat > "$WRAPPER_DIR/tailscale" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+real="${REAL_TAILSCALE}"
+socket="${TS_SOCKET}"
+
+if [ "\${1:-}" = "version" ]; then
+  exec "\$real" "\$@"
+fi
+
+exec "\$real" --socket "\$socket" "\$@"
+EOF
+chmod +x "$WRAPPER_DIR/tailscale"
+
+"$REAL_TAILSCALED" --state="$TS_STATE" --socket="$TS_SOCKET" --tun=userspace-networking >"$TS_LOG" 2>&1 &
+TAILSCALED_PID="$!"
+
+for _ in $(seq 1 30); do
+  if [ -S "$TS_SOCKET" ]; then
+    break
+  fi
+  sleep 1
+done
+
+if [ ! -S "$TS_SOCKET" ]; then
+  echo "tailscaled socket did not appear" >&2
+  cat "$TS_LOG" >&2 || true
+  exit 1
+fi
+
+cat > "$CONFIG_PATH" <<'JSON'
+{
+  "defaultPreset": "live-e2e-linux",
+  "operatorPasswordEnv": "TAILSTICK_OPERATOR_PASSWORD",
+  "presets": [
+    {
+      "id": "live-e2e-linux",
+      "description": "live isolated Linux E2E",
+      "authKeyEnv": "TAILSTICK_AUTH_KEY",
+      "cleanup": {
+        "tailnet": "live-e2e",
+        "apiKeyEnv": "TAILSTICK_API_KEY",
+        "deviceDeleteEnabled": true
+      }
+    }
+  ]
+}
+JSON
+
+export PATH="$WRAPPER_DIR:$PATH"
+
+"$TAILSTICK_BIN" run \
+  --config "$CONFIG_PATH" \
+  --state "$STATE_PATH" \
+  --log "$LOG_PATH" \
+  --audit "$AUDIT_PATH" \
+  --preset live-e2e-linux \
+  --mode timed \
+  --days 1 \
+  --channel latest \
+  --allow-existing \
+  --password "$TAILSTICK_OPERATOR_PASSWORD"
+
+LEASE_ID="$(jq -r '.records[0].leaseId' "$STATE_PATH")"
+DEVICE_ID="$(jq -r '.records[0].deviceId' "$STATE_PATH")"
+CREDENTIAL_REF="$(jq -r '.records[0].credentialRef' "$STATE_PATH")"
+STATUS="$(jq -r '.records[0].status' "$STATE_PATH")"
+
+test "$STATUS" = "active"
+test -n "$LEASE_ID"
+test -n "$DEVICE_ID"
+test -f "$CREDENTIAL_REF"
+test -f /var/lib/tailstick/tailstick-agent
+test -f /etc/systemd/system/tailstick-agent.service
+test -f /etc/systemd/system/tailstick-agent.timer
+systemctl is-enabled tailstick-agent.timer >/dev/null
+
+curl -fsS -u "${TAILSTICK_API_KEY}:" "https://api.tailscale.com/api/v2/device/${DEVICE_ID}" >/dev/null
+
+"$TAILSTICK_BIN" cleanup \
+  --config "$CONFIG_PATH" \
+  --state "$STATE_PATH" \
+  --log "$LOG_PATH" \
+  --audit "$AUDIT_PATH" \
+  --lease-id "$LEASE_ID"
+
+STATUS_AFTER_CLEANUP="$(jq -r '.records[0].status' "$STATE_PATH")"
+test "$STATUS_AFTER_CLEANUP" = "cleaned"
+test ! -f "$CREDENTIAL_REF"
+
+wait_for_device_gone "$DEVICE_ID"
+DEVICE_ID=""
+
+"$TAILSTICK_BIN" agent --once \
+  --config "$CONFIG_PATH" \
+  --state "$STATE_PATH" \
+  --log "$LOG_PATH" \
+  --audit "$AUDIT_PATH"
+
+test ! -f /var/lib/tailstick/tailstick-agent
+test ! -f /etc/systemd/system/tailstick-agent.service
+test ! -f /etc/systemd/system/tailstick-agent.timer
+
+echo "linux-live-e2e: PASS"

--- a/tests/live/windows-live-e2e.ps1
+++ b/tests/live/windows-live-e2e.ps1
@@ -1,0 +1,169 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Require-Env([string]$Name) {
+  if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($Name))) {
+    throw "missing required env: $Name"
+  }
+}
+
+function Get-BasicAuthHeader([string]$ApiKey) {
+  $tokenBytes = [System.Text.Encoding]::ASCII.GetBytes("${ApiKey}:")
+  return @{
+    Authorization = "Basic $([Convert]::ToBase64String($tokenBytes))"
+  }
+}
+
+function Wait-ForDeviceGone([string]$DeviceId, [hashtable]$Headers) {
+  for ($i = 0; $i -lt 30; $i++) {
+    try {
+      Invoke-RestMethod -Method Get -Uri "https://api.tailscale.com/api/v2/device/$DeviceId" -Headers $Headers | Out-Null
+      Start-Sleep -Seconds 2
+    } catch {
+      $statusCode = $_.Exception.Response.StatusCode.value__
+      if ($statusCode -eq 404) {
+        return
+      }
+      Start-Sleep -Seconds 2
+    }
+  }
+
+  throw "device $DeviceId still exists after cleanup"
+}
+
+Require-Env "TAILSTICK_EPHEMERAL_AUTH_KEY"
+Require-Env "TAILSTICK_API_KEY"
+Require-Env "TAILSTICK_OPERATOR_PASSWORD"
+
+$workspace = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+$bin = Join-Path $workspace "dist\tailstick-windows-cli.exe"
+$workDir = Join-Path $env:TEMP "tailstick-live-e2e"
+$configPath = Join-Path $workDir "tailstick.config.json"
+$statePath = Join-Path $workDir "state.json"
+$logPath = Join-Path $workDir "tailstick.log"
+$auditPath = Join-Path $workDir "audit.ndjson"
+$programDataRoot = if ($env:ProgramData) { $env:ProgramData } else { "C:\ProgramData" }
+$agentBinaryPath = Join-Path $programDataRoot "TailStick\tailstick-agent.exe"
+$headers = Get-BasicAuthHeader $env:TAILSTICK_API_KEY
+$deviceId = $null
+
+New-Item -Path $workDir -ItemType Directory -Force | Out-Null
+
+$config = @'
+{
+  "defaultPreset": "live-e2e-windows",
+  "operatorPasswordEnv": "TAILSTICK_OPERATOR_PASSWORD",
+  "presets": [
+    {
+      "id": "live-e2e-windows",
+      "description": "live Windows E2E",
+      "ephemeralAuthKeyEnv": "TAILSTICK_EPHEMERAL_AUTH_KEY",
+      "cleanup": {
+        "tailnet": "live-e2e",
+        "apiKeyEnv": "TAILSTICK_API_KEY",
+        "deviceDeleteEnabled": true
+      }
+    }
+  ]
+}
+'@
+$config | Set-Content -Path $configPath -Encoding UTF8
+
+try {
+  $runOutput = ((& $bin run `
+    --config $configPath `
+    --state $statePath `
+    --log $logPath `
+    --audit $auditPath `
+    --preset live-e2e-windows `
+    --mode session `
+    --channel latest `
+    --allow-existing `
+    --password $env:TAILSTICK_OPERATOR_PASSWORD 2>&1) | Out-String).Trim()
+
+  if ($LASTEXITCODE -ne 0) {
+    throw "run command failed: $runOutput"
+  }
+
+  $state = Get-Content -Path $statePath -Raw | ConvertFrom-Json
+  $record = $state.records | Select-Object -First 1
+  if ($null -eq $record) {
+    throw "state file did not contain a lease record"
+  }
+  if ($record.status -ne "active") {
+    throw "expected active state after enrollment, got $($record.status)"
+  }
+
+  $deviceId = $record.deviceId
+  $credentialRef = $record.credentialRef
+  if ([string]::IsNullOrWhiteSpace($deviceId)) {
+    throw "device id missing from state"
+  }
+  if ([string]::IsNullOrWhiteSpace($credentialRef) -or -not (Test-Path $credentialRef)) {
+    throw "credential ref missing or unreadable"
+  }
+
+  Invoke-RestMethod -Method Get -Uri "https://api.tailscale.com/api/v2/device/$deviceId" -Headers $headers | Out-Null
+
+  Get-ScheduledTask -TaskName "TailStickAgent-Startup" | Out-Null
+  Get-ScheduledTask -TaskName "TailStickAgent-Periodic" | Out-Null
+
+  if (-not (Test-Path $agentBinaryPath)) {
+    throw "expected agent binary at $agentBinaryPath"
+  }
+
+  $cleanupOutput = ((& $bin cleanup `
+    --config $configPath `
+    --state $statePath `
+    --log $logPath `
+    --audit $auditPath `
+    --lease-id $record.leaseId 2>&1) | Out-String).Trim()
+
+  if ($LASTEXITCODE -ne 0) {
+    throw "cleanup command failed: $cleanupOutput"
+  }
+
+  $stateAfterCleanup = Get-Content -Path $statePath -Raw | ConvertFrom-Json
+  $recordAfterCleanup = $stateAfterCleanup.records | Select-Object -First 1
+  if ($recordAfterCleanup.status -ne "cleaned") {
+    throw "expected cleaned state after cleanup, got $($recordAfterCleanup.status)"
+  }
+  if (Test-Path $credentialRef) {
+    throw "credential ref should be removed after cleanup"
+  }
+
+  Wait-ForDeviceGone -DeviceId $deviceId -Headers $headers
+  $deviceId = $null
+
+  $agentOutput = ((& $bin agent `
+    --once `
+    --config $configPath `
+    --state $statePath `
+    --log $logPath `
+    --audit $auditPath 2>&1) | Out-String).Trim()
+
+  if ($LASTEXITCODE -ne 0) {
+    throw "agent --once command failed: $agentOutput"
+  }
+
+  if ($null -ne (Get-ScheduledTask -TaskName "TailStickAgent-Startup" -ErrorAction SilentlyContinue)) {
+    throw "startup task still exists after self-removal"
+  }
+  if ($null -ne (Get-ScheduledTask -TaskName "TailStickAgent-Periodic" -ErrorAction SilentlyContinue)) {
+    throw "periodic task still exists after self-removal"
+  }
+
+  Start-Sleep -Seconds 5
+  if (Test-Path $agentBinaryPath) {
+    throw "agent binary still exists after self-removal"
+  }
+
+  Write-Host "windows-live-e2e: PASS"
+} finally {
+  if (-not [string]::IsNullOrWhiteSpace($deviceId)) {
+    try {
+      Invoke-RestMethod -Method Delete -Uri "https://api.tailscale.com/api/v2/device/$deviceId" -Headers $headers | Out-Null
+    } catch {
+    }
+  }
+}


### PR DESCRIPTION
**Summary**
- add a manual `live-e2e` workflow for real Tailscale-backed validation
- add an isolated Linux live E2E lane and a hosted Windows live E2E lane
- document the required GitHub Actions secrets and isolation model

**Verification**
- `go test ./...`
- `bash -n tests/live/linux-live-e2e.sh`
- PowerShell parser check for `tests/live/windows-live-e2e.ps1`

This workflow is manual-only and does not run on PRs automatically.