### PR TITLE
[nightshift] docs-backfill: add godoc comments to all packages

### DIFF
--- a/cmd/tailstick-linux-cli/main.go
+++ b/cmd/tailstick-linux-cli/main.go
@@ -1,3 +1,4 @@
+// Package main is the Linux CLI entry point for tailstick.
 package main
 
 import (

--- a/cmd/tailstick-linux-gui/main.go
+++ b/cmd/tailstick-linux-gui/main.go
@@ -1,3 +1,4 @@
+// Package main is the Linux GUI entry point for tailstick.
 package main
 
 import (

--- a/cmd/tailstick-windows-cli/main.go
+++ b/cmd/tailstick-windows-cli/main.go
@@ -1,3 +1,4 @@
+// Package main is the Windows CLI entry point for tailstick.
 package main
 
 import (

--- a/cmd/tailstick-windows-gui/main.go
+++ b/cmd/tailstick-windows-gui/main.go
@@ -1,3 +1,4 @@
+// Package main is the Windows GUI entry point for tailstick.
 package main
 
 import (

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -1,3 +1,5 @@
+// Package app implements the tailstick CLI and GUI command surfaces, orchestrating
+// enrollment, agent reconciliation, and cleanup workflows.
 package app
 
 import (
@@ -13,8 +15,11 @@ import (
 	"github.com/tailstick/tailstick/internal/model"
 )
 
+// Version is the current tailstick release version.
 const Version = "1.0.0"
 
+// RunCLI is the main entry point for the tailstick command-line interface.
+// It dispatches to subcommands (run, agent, cleanup, version, help).
 func RunCLI(args []string, rt Runtime) int {
 	if len(args) == 0 {
 		return runEnroll(args, rt)

--- a/internal/app/gui.go
+++ b/internal/app/gui.go
@@ -8,6 +8,8 @@ import (
 	"github.com/tailstick/tailstick/internal/gui"
 )
 
+// RunGUI is the main entry point for the tailstick web-based GUI.
+// It starts a local HTTP server and optionally opens the browser.
 func RunGUI(args []string, rt Runtime) int {
 	fs := flag.NewFlagSet("gui", flag.ContinueOnError)
 	var (

--- a/internal/app/workflow.go
+++ b/internal/app/workflow.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tailstick/tailstick/internal/tailscale"
 )
 
+// Runtime holds the resolved filesystem paths and flags shared across CLI and GUI entry points.
 type Runtime struct {
 	ConfigPath string
 	StatePath  string
@@ -31,6 +32,7 @@ type Runtime struct {
 	DryRun     bool
 }
 
+// Manager orchestrates the tailstick lifecycle: enrollment, agent reconciliation, and cleanup.
 type Manager struct {
 	Runtime Runtime
 	Logger  *logging.Logger
@@ -39,6 +41,8 @@ type Manager struct {
 	HostCtx platform.Context
 }
 
+// NewManager initializes a Manager by detecting the host platform, resolving paths,
+// creating required directories, and opening the log file.
 func NewManager(rt Runtime) (*Manager, error) {
 	host, err := platform.Detect()
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,4 @@
+// Package config handles loading, validating, and resolving tailstick configuration files.
 package config
 
 import (
@@ -15,6 +16,8 @@ const (
 	DefaultConfigFile = "tailstick.config.json"
 )
 
+// Load reads and parses a tailstick configuration file, expanding environment variables
+// and validating the result.
 func Load(path string) (model.Config, error) {
 	if path == "" {
 		path = DefaultConfigFile
@@ -40,6 +43,7 @@ func Load(path string) (model.Config, error) {
 	return cfg, nil
 }
 
+// Validate checks that the configuration has at least one preset with valid IDs and auth material.
 func Validate(cfg model.Config) error {
 	if len(cfg.Presets) == 0 {
 		return errors.New("config must define at least one preset")
@@ -65,6 +69,7 @@ func Validate(cfg model.Config) error {
 	return nil
 }
 
+// FindPreset returns the preset matching the given id, the default preset, or the first preset.
 func FindPreset(cfg model.Config, id string) (model.Preset, error) {
 	if id == "" {
 		id = cfg.DefaultPreset
@@ -80,6 +85,7 @@ func FindPreset(cfg model.Config, id string) (model.Preset, error) {
 	return model.Preset{}, fmt.Errorf("preset %q not found", id)
 }
 
+// ResolvePath returns an absolute path by joining baseDir with the given relative path.
 func ResolvePath(baseDir, path string) string {
 	if path == "" {
 		return ""
@@ -90,6 +96,7 @@ func ResolvePath(baseDir, path string) string {
 	return filepath.Join(baseDir, path)
 }
 
+// ResolvePresetSecrets fills in secret values from environment variables for each preset field.
 func ResolvePresetSecrets(p model.Preset) model.Preset {
 	out := p
 	if strings.TrimSpace(out.AuthKey) == "" && strings.TrimSpace(out.AuthKeyEnv) != "" {

--- a/internal/crypto/secret.go
+++ b/internal/crypto/secret.go
@@ -1,3 +1,5 @@
+// Package crypto provides AES-GCM encryption and decryption of secrets using
+// scrypt-derived keys, bound to either a password or the host machine context.
 package crypto
 
 import (
@@ -14,6 +16,7 @@ import (
 	"golang.org/x/crypto/scrypt"
 )
 
+// Envelope holds the encrypted payload metadata: key derivation mode, salt, nonce, and ciphertext.
 type Envelope struct {
 	Mode   string `json:"mode"`
 	Salt   string `json:"salt"`
@@ -21,6 +24,8 @@ type Envelope struct {
 	Cipher string `json:"cipher"`
 }
 
+// Encrypt encrypts plaintext using AES-256-GCM with a key derived from the password
+// (or machine context if password is empty). Returns a base64-encoded JSON envelope.
 func Encrypt(plain, password, machineContext string) (string, error) {
 	key, salt, mode, err := deriveKey(password, machineContext)
 	if err != nil {
@@ -52,6 +57,7 @@ func Encrypt(plain, password, machineContext string) (string, error) {
 	return base64.StdEncoding.EncodeToString(b), nil
 }
 
+// Decrypt reverses Encrypt, decoding the base64 envelope and decrypting with the same key material.
 func Decrypt(encoded, password, machineContext string) (string, error) {
 	raw, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {

--- a/internal/gui/server.go
+++ b/internal/gui/server.go
@@ -1,3 +1,4 @@
+// Package gui serves a browser-based enrollment UI via an embedded HTTP server.
 package gui
 
 import (
@@ -21,6 +22,7 @@ import (
 //go:embed index.html tailstick-favicon.png
 var staticFS embed.FS
 
+// Server is the GUI HTTP handler holder with config path, logging, and enrollment callback.
 type Server struct {
 	ConfigPath string
 	Logf       func(format string, args ...any)
@@ -39,6 +41,8 @@ type enrollRequest struct {
 	Password      string `json:"password"`
 }
 
+// Run starts the GUI HTTP server on the given host:port, serving the embedded UI and API endpoints.
+// If openBrowser is true, it attempts to launch the system browser automatically.
 func Run(ctx context.Context, srv *Server, openBrowser bool, host string, port int) error {
 	host = strings.TrimSpace(host)
 	if host == "" {

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,3 +1,4 @@
+// Package logging provides a simple dual-output logger that writes to both a file and stdout.
 package logging
 
 import (
@@ -9,12 +10,14 @@ import (
 	"time"
 )
 
+// Logger writes timestamped log lines to both a file and stdout.
 type Logger struct {
 	mu   sync.Mutex
 	file *os.File
 	std  *log.Logger
 }
 
+// New creates a Logger that appends to the file at the given path.
 func New(path string) (*Logger, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, err

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -1,7 +1,10 @@
+// Package model defines the core domain types for tailstick, including lease
+// configurations, presets, state records, and Tailscale API response shapes.
 package model
 
 import "time"
 
+// LeaseMode represents the duration policy for a tailscale enrollment lease.
 type LeaseMode string
 
 const (
@@ -10,6 +13,7 @@ const (
 	LeaseModePermanent LeaseMode = "permanent"
 )
 
+// Channel specifies the tailscale installation release channel.
 type Channel string
 
 const (
@@ -17,6 +21,7 @@ const (
 	ChannelLatest Channel = "latest"
 )
 
+// LeaseStatus tracks the lifecycle phase of a lease record.
 type LeaseStatus string
 
 const (
@@ -26,6 +31,7 @@ const (
 	LeaseStatusCleaned       LeaseStatus = "cleaned"
 )
 
+// Config is the top-level tailstick configuration loaded from tailstick.config.json.
 type Config struct {
 	StableVersion       string   `json:"stableVersion"`
 	DefaultPreset       string   `json:"defaultPreset"`
@@ -34,6 +40,7 @@ type Config struct {
 	Presets             []Preset `json:"presets"`
 }
 
+// Preset defines a named enrollment profile with auth keys, tags, and install/cleanup commands.
 type Preset struct {
 	ID                     string   `json:"id"`
 	Description            string   `json:"description"`
@@ -50,6 +57,7 @@ type Preset struct {
 	Cleanup                Cleanup  `json:"cleanup"`
 }
 
+// Install holds platform-specific install and uninstall command templates for tailscale.
 type Install struct {
 	LinuxStable      []string `json:"linuxStable"`
 	LinuxLatest      []string `json:"linuxLatest"`
@@ -59,6 +67,7 @@ type Install struct {
 	WindowsUninstall []string `json:"windowsUninstall"`
 }
 
+// Cleanup configures post-lease device deletion via the Tailscale API.
 type Cleanup struct {
 	Tailnet             string `json:"tailnet"`
 	APIKey              string `json:"apiKey"`
@@ -66,6 +75,7 @@ type Cleanup struct {
 	DeviceDeleteEnabled bool   `json:"deviceDeleteEnabled"`
 }
 
+// RuntimeOptions holds the resolved operator inputs for a single enrollment invocation.
 type RuntimeOptions struct {
 	PresetID       string
 	Mode           LeaseMode
@@ -79,6 +89,7 @@ type RuntimeOptions struct {
 	Password       string
 }
 
+// LeaseRecord is the persistent state of a single enrollment lease, stored in state.json.
 type LeaseRecord struct {
 	LeaseID             string      `json:"leaseId"`
 	PresetID            string      `json:"presetId"`
@@ -102,12 +113,14 @@ type LeaseRecord struct {
 	EncryptedSecret     string      `json:"encryptedSecret,omitempty"`
 }
 
+// LocalState is the on-disk state file containing all lease records.
 type LocalState struct {
 	SchemaVersion int           `json:"schemaVersion"`
 	UpdatedAt     time.Time     `json:"updatedAt"`
 	Records       []LeaseRecord `json:"records"`
 }
 
+// AuditEntry is a single line in the audit log, recording a lease lifecycle event.
 type AuditEntry struct {
 	Timestamp  time.Time `json:"timestamp"`
 	LeaseID    string    `json:"leaseId"`
@@ -120,12 +133,14 @@ type AuditEntry struct {
 	Message    string    `json:"message"`
 }
 
+// TailscaleSelf contains the identity fields from the tailscale status API.
 type TailscaleSelf struct {
 	ID       string `json:"ID"`
 	DNSName  string `json:"DNSName"`
 	HostName string `json:"HostName"`
 }
 
+// TailscaleStatus is the parsed output of "tailscale status --json".
 type TailscaleStatus struct {
 	Self TailscaleSelf `json:"Self"`
 }

--- a/internal/platform/exec.go
+++ b/internal/platform/exec.go
@@ -1,3 +1,4 @@
+// Package exec provides a command runner abstraction with optional dry-run mode.
 package platform
 
 import (
@@ -9,6 +10,7 @@ import (
 	"time"
 )
 
+// Runner executes system commands, with optional dry-run mode that prints without executing.
 type Runner struct {
 	DryRun bool
 }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -1,3 +1,5 @@
+// Package platform provides host detection, path resolution, and privilege checks
+// for supported operating systems (Linux and Windows).
 package platform
 
 import (
@@ -11,6 +13,8 @@ import (
 	"strings"
 )
 
+// Context holds detected host properties including OS, architecture, hostname,
+// boot ID, and the executable path of the running binary.
 type Context struct {
 	OS      string
 	Arch    string
@@ -19,6 +23,7 @@ type Context struct {
 	ExePath string
 }
 
+// Detect collects the current host's OS, architecture, hostname, boot ID, and executable path.
 func Detect() (Context, error) {
 	host, err := os.Hostname()
 	if err != nil {
@@ -39,9 +44,13 @@ func Detect() (Context, error) {
 	return ctx, nil
 }
 
+// IsLinux returns true when running on a Linux host.
 func IsLinux() bool   { return runtime.GOOS == "linux" }
+
+// IsWindows returns true when running on a Windows host.
 func IsWindows() bool { return runtime.GOOS == "windows" }
 
+// StatePath returns the platform-specific path for the state.json file.
 func StatePath() string {
 	if IsWindows() {
 		root := os.Getenv("ProgramData")
@@ -53,6 +62,7 @@ func StatePath() string {
 	return "/var/lib/tailstick/state.json"
 }
 
+// LogPath returns the platform-specific path for the tailstick log file.
 func LogPath() string {
 	if IsWindows() {
 		root := os.Getenv("ProgramData")
@@ -64,6 +74,7 @@ func LogPath() string {
 	return "/var/log/tailstick.log"
 }
 
+// LocalSecretPath returns the platform-specific directory for locally encrypted secrets.
 func LocalSecretPath() string {
 	if IsWindows() {
 		root := os.Getenv("ProgramData")
@@ -75,6 +86,7 @@ func LocalSecretPath() string {
 	return "/var/lib/tailstick/secrets"
 }
 
+// AgentBinaryPath returns the platform-specific path where the reconciliation agent binary is installed.
 func AgentBinaryPath() string {
 	if IsWindows() {
 		root := os.Getenv("ProgramData")
@@ -86,6 +98,7 @@ func AgentBinaryPath() string {
 	return "/var/lib/tailstick/tailstick-agent"
 }
 
+// EnsureParent creates all directories in the path of the given file's parent directory.
 func EnsureParent(path string) error {
 	parent := filepath.Dir(path)
 	if err := os.MkdirAll(parent, 0o755); err != nil {
@@ -137,6 +150,7 @@ func sanitizeHost(in string) string {
 	return strings.Trim(string(out), "-")
 }
 
+// RequireSupportedLinux returns an error if the current Linux distribution is not Debian or Ubuntu.
 func RequireSupportedLinux() error {
 	if !IsLinux() {
 		return nil
@@ -152,6 +166,7 @@ func RequireSupportedLinux() error {
 	return errors.New("linux target unsupported: only debian/ubuntu are supported in v1")
 }
 
+// IsElevated reports whether the current process is running with administrator/root privileges.
 func IsElevated() bool {
 	if IsLinux() {
 		return os.Geteuid() == 0
@@ -164,6 +179,7 @@ func IsElevated() bool {
 	return true
 }
 
+// ElevationHint returns a human-readable message describing how to re-run with elevated privileges.
 func ElevationHint(exePath string, args []string) string {
 	if IsLinux() {
 		return "rerun with sudo"

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -1,3 +1,4 @@
+// Package state manages the on-disk JSON state file and append-only audit log.
 package state
 
 import (
@@ -10,6 +11,7 @@ import (
 	"github.com/tailstick/tailstick/internal/model"
 )
 
+// Load reads the state file, returning an empty default state if the file does not exist.
 func Load(path string) (model.LocalState, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
@@ -31,6 +33,7 @@ func Load(path string) (model.LocalState, error) {
 	return st, nil
 }
 
+// Save atomically writes the state to disk via a temp-and-rename strategy.
 func Save(path string, st model.LocalState) error {
 	st.SchemaVersion = 1
 	st.UpdatedAt = time.Now().UTC()
@@ -49,6 +52,7 @@ func Save(path string, st model.LocalState) error {
 	return os.Rename(tmp, path)
 }
 
+// UpsertRecord inserts or replaces a lease record by LeaseID.
 func UpsertRecord(st model.LocalState, rec model.LeaseRecord) model.LocalState {
 	for i := range st.Records {
 		if st.Records[i].LeaseID == rec.LeaseID {
@@ -60,6 +64,7 @@ func UpsertRecord(st model.LocalState, rec model.LeaseRecord) model.LocalState {
 	return st
 }
 
+// AppendAudit appends a JSON-encoded audit entry to the NDJSON audit log file.
 func AppendAudit(path string, entry model.AuditEntry) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err

--- a/internal/tailscale/client.go
+++ b/internal/tailscale/client.go
@@ -1,3 +1,5 @@
+// Package tailscale provides a client wrapper around the tailscale CLI and API
+// for device enrollment, status checks, and device deletion.
 package tailscale
 
 import (
@@ -15,6 +17,7 @@ import (
 	"github.com/tailstick/tailstick/internal/platform"
 )
 
+// Client wraps tailscale CLI operations and the Tailscale API for device management.
 type Client struct {
 	Runner platform.Runner
 }
@@ -131,6 +134,8 @@ func (c Client) Uninstall(ctx context.Context, preset model.Preset) error {
 	return err
 }
 
+// DeleteDevice removes a device from the tailnet using the Tailscale API.
+// It is a no-op if either apiKey or deviceID is empty.
 func DeleteDevice(ctx context.Context, apiKey, deviceID string) error {
 	if strings.TrimSpace(apiKey) == "" || strings.TrimSpace(deviceID) == "" {
 		return nil
@@ -188,6 +193,8 @@ func uninstallCommand(preset model.Preset) []string {
 	return []string{"bash", "-lc", "apt-get remove -y tailscale"}
 }
 
+// BuildMachineContext constructs a machine-bound context string from the OS, architecture,
+// hostname, and (on Linux) the machine-id. Used to bind encrypted secrets to a host.
 func BuildMachineContext(host, _ string) string {
 	info := []string{runtime.GOOS, runtime.GOARCH, strings.ToLower(strings.TrimSpace(host))}
 	if runtime.GOOS == "linux" {
@@ -198,6 +205,7 @@ func BuildMachineContext(host, _ string) string {
 	return strings.Join(info, "|")
 }
 
+// ParseDurationDays resolves the effective lease duration in days based on mode and operator inputs.
 func ParseDurationDays(mode model.LeaseMode, defaultDays, customDays int) (int, error) {
 	switch mode {
 	case model.LeaseModeSession:
@@ -222,6 +230,7 @@ func ParseDurationDays(mode model.LeaseMode, defaultDays, customDays int) (int, 
 	}
 }
 
+// Future returns a time pointer set to ts plus the given number of days, or nil if days <= 0.
 func Future(ts time.Time, days int) *time.Time {
 	if days <= 0 {
 		return nil


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** docs-backfill
**Category:** pr
**Changes:** Added package-level and exported-declaration godoc comments across all 16 Go source files (82 lines). Every exported type, function, constant, and variable now has a proper doc comment.

Merge if useful, close if not.