### PR TITLE
[nightshift] dead-code: remove unused ResolvePath, RunWithTimeout, and HostName field

### DIFF
--- a/internal/app/workflow_test.go
+++ b/internal/app/workflow_test.go
@@ -467,7 +467,7 @@ case "${1:-}" in
     echo "1.0.0"
     ;;
   status)
-    echo '{"Self":{"ID":"device-123","DNSName":"node.example.ts.net","HostName":"dev-box"}}'
+    echo '{\"Self\":{\"ID\":\"device-123\",\"DNSName\":\"node.example.ts.net\"}}'
     ;;
 esac
 `, logPath)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/tailstick/tailstick/internal/model"
@@ -78,16 +77,6 @@ func FindPreset(cfg model.Config, id string) (model.Preset, error) {
 		}
 	}
 	return model.Preset{}, fmt.Errorf("preset %q not found", id)
-}
-
-func ResolvePath(baseDir, path string) string {
-	if path == "" {
-		return ""
-	}
-	if filepath.IsAbs(path) {
-		return path
-	}
-	return filepath.Join(baseDir, path)
 }
 
 func ResolvePresetSecrets(p model.Preset) model.Preset {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -121,9 +121,8 @@ type AuditEntry struct {
 }
 
 type TailscaleSelf struct {
-	ID       string `json:"ID"`
-	DNSName  string `json:"DNSName"`
-	HostName string `json:"HostName"`
+	ID      string `json:"ID"`
+	DNSName string `json:"DNSName"`
 }
 
 type TailscaleStatus struct {

--- a/internal/platform/exec.go
+++ b/internal/platform/exec.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
-	"time"
 )
 
 type Runner struct {
@@ -29,10 +28,4 @@ func (r Runner) Run(ctx context.Context, args []string) (string, error) {
 		return out.String(), fmt.Errorf("%w: %s", err, strings.TrimSpace(out.String()))
 	}
 	return out.String(), nil
-}
-
-func (r Runner) RunWithTimeout(timeout time.Duration, args []string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	return r.Run(ctx, args)
 }

--- a/internal/tailscale/client.go
+++ b/internal/tailscale/client.go
@@ -116,9 +116,6 @@ func (c Client) Status(ctx context.Context) (model.TailscaleStatus, error) {
 	if v, ok := selfRaw["DNSName"].(string); ok {
 		st.Self.DNSName = v
 	}
-	if v, ok := selfRaw["HostName"].(string); ok {
-		st.Self.HostName = v
-	}
 	return st, nil
 }
 


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** dead-code — Dead Code Removal
**Category:** pr
**Cost Tier:** medium

## Changes

Removes 3 unused code items found via static analysis:

1. **`config.ResolvePath()`** — exported function never called anywhere. Also removes now-unused `path/filepath` import.

2. **`Runner.RunWithTimeout()`** — method never called; all callers construct their own contexts with timeouts directly.

3. **`TailscaleSelf.HostName`** field — populated during status parsing but never read by any consumer. Only `ID` and `DNSName` are used.

## Files Modified
- `internal/config/config.go` — removed `ResolvePath` + unused `filepath` import (−11 lines)
- `internal/platform/exec.go` — removed `RunWithTimeout` + unused `time` import (−7 lines)
- `internal/model/types.go` — removed `HostName` field from `TailscaleSelf` (−2 lines)
- `internal/tailscale/client.go` — removed `HostName` assignment in fallback parser (−3 lines)
- `internal/app/workflow_test.go` — updated test fixture to match trimmed struct (1 line)

**Total: −25 lines, net −22 lines of dead code removed.**

Merge if useful, close if not.
