### PR TITLE
[nightshift] docs-backfill: add package doc comments and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to tailstick
+
+Thanks for your interest in contributing. This guide covers the basics.
+
+## Development Setup
+
+1. **Go 1.22+** is required.
+2. Clone the repository and build:
+   ```bash
+   go build ./...
+   ```
+3. Run the test suite:
+   ```bash
+   go test ./...
+   ```
+
+## Code Style
+
+- Follow standard Go conventions (`gofmt`, `go vet`).
+- All exported functions and types must have doc comments.
+- Package-level doc comments should describe the package's purpose in 2-3 sentences.
+
+## Pull Requests
+
+- Open PRs against the `main` branch.
+- Include a clear description of what the change does and why.
+- Keep PRs focused — one concern per PR is preferred.
+- Ensure `go test ./...` and `go vet ./...` pass before requesting review.
+
+## Architecture
+
+See [docs/architecture.md](docs/architecture.md) for the system design. Key packages:
+
+| Package | Purpose |
+|---------|---------|
+| `internal/app` | Core runtime, CLI commands, and GUI server |
+| `internal/tailscale` | Tailscale CLI and API client |
+| `internal/state` | Persistent lease storage |
+| `internal/crypto` | AES-GCM encryption for secrets |
+| `internal/config` | Configuration loading and validation |
+| `internal/gui` | Browser-based setup wizard |
+| `internal/logging` | Structured file logging with rotation |
+| `internal/model` | Core domain types |
+| `internal/platform` | OS abstraction and command execution |
+
+## Reporting Issues
+
+Open a GitHub issue with:
+- The platform and version you're running (`tailstick version`).
+- Steps to reproduce.
+- Expected vs actual behavior.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/internal/app/workflow.go
+++ b/internal/app/workflow.go
@@ -1,3 +1,6 @@
+// Package app implements the core tailstick runtime, CLI commands, and GUI server.
+// It coordinates lease lifecycle operations (create, reconcile, cleanup) by composing
+// the tailscale client, state store, crypto, and platform packages.
 package app
 
 import (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,6 @@
+// Package config handles loading and validation of tailstick.config.json.
+// It parses preset definitions, lease mode defaults, exit node allowlists,
+// and provides the runtime configuration used by all other packages.
 package config
 
 import (

--- a/internal/crypto/secret.go
+++ b/internal/crypto/secret.go
@@ -1,3 +1,6 @@
+// Package crypto provides AES-GCM encryption and decryption for sensitive
+// configuration values (auth keys, API keys, operator passwords).
+// Secrets are encrypted with a key derived from a machine-specific salt.
 package crypto
 
 import (

--- a/internal/gui/server.go
+++ b/internal/gui/server.go
@@ -1,3 +1,6 @@
+// Package gui serves the browser-based setup wizard via a local HTTP server.
+// It embeds static assets (HTML, favicon) and exposes REST endpoints for
+// preset selection, mode configuration, and lease creation.
 package gui
 
 import (

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,3 +1,6 @@
+// Package logging provides structured, file-based logging with automatic
+// rotation. Log files are written to a platform-specific directory and
+// rotated by size to prevent unbounded growth.
 package logging
 
 import (

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -1,3 +1,5 @@
+// Package model defines the core domain types for tailstick: leases, presets,
+// configuration shapes, channel selectors, and lease lifecycle events.
 package model
 
 import "time"

--- a/internal/platform/exec.go
+++ b/internal/platform/exec.go
@@ -1,3 +1,6 @@
+// Package platform abstracts OS-specific command execution and service management.
+// It provides a Runner interface for shelling out to system commands and platform
+// detection for Linux and Windows environments.
 package platform
 
 import (

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -1,3 +1,6 @@
+// Package state manages persistent lease storage on disk.
+// It reads and writes lease records as JSON files, providing the canonical
+// source of truth for active and historical leases.
 package state
 
 import (

--- a/internal/tailscale/client.go
+++ b/internal/tailscale/client.go
@@ -1,3 +1,6 @@
+// Package tailscale provides a client for interacting with the Tailscale CLI and API.
+// It handles installation checks, auth key-based enrollment, device deletion via the
+// Tailscale API, and status queries.
 package tailscale
 
 import (


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** Documentation Backfiller
**Category:** pr
**Changes:**
- Add `// Package` doc comments to all 9 internal Go packages (app, tailscale, state, crypto, gui, logging, model, platform, config)
- Create CONTRIBUTING.md with development setup, code style guidelines, PR conventions, architecture reference table, and issue reporting template

Merge if useful, close if not.