### PR TITLE
[nightshift] readme-improvements: automated improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,16 @@
 
 if you need to get a field machine onto your tailnet without building a backend service around the process, tailstick gives you a controlled local workflow. it keeps the operator flow simple, supports session, timed, and permanent access, and keeps cleanup tied to the same lease record instead of spreading state across ad hoc scripts.
 
+## requirements
+
+- **elevated privileges** are required for enrollment and cleanup (`sudo` on linux, administrator on windows).
+- **linux**: debian or ubuntu with `systemd`. other distributions are not supported in the current release.
+- **windows**: standard windows with scheduled tasks available.
+- **go 1.22+** is required for building from source.
+
 ## quickstart
 
-1. go to [releases](https://github.com/Microck/tailstick/releases/latest) and download the binary you want for your machine. use the cli if you want a direct command flow, or use the gui if you want the local browser flow.
+1. go to [releases](https://github.com/Microck/tailstick/releases/latest) and download the binary you want for your machine. use the cli if you want a direct command flow, or use the gui if you want the local browser flow. binaries are available for `linux/amd64`, `linux/arm64`, `windows/amd64`, and `windows/arm64`.
 2. put that binary in a working folder, then place a `tailstick.config.json` file next to it.
 3. write that config by hand from `configs/tailstick.config.example.json`, or use the optional [preset maker](https://tailstick.micr.dev/) if you want a faster way to build it.
 4. make sure you have the secrets your presets depend on. in most setups that means a tailscale auth key, a tailscale ephemeral auth key, and a tailscale api key for cleanup. if you want password-gated operator use, you also need an operator password.
@@ -39,6 +46,8 @@ for normal operator use, use the release binaries. building from source is only 
 | linux (debian/ubuntu + `systemd`) | supported | supported | supported |
 | windows | supported | supported | supported |
 
+release binaries are built for `linux/amd64`, `linux/arm64`, `windows/amd64`, and `windows/arm64`.
+
 ## command surface
 
 | command | purpose |
@@ -47,6 +56,61 @@ for normal operator use, use the release binaries. building from source is only 
 | `tailstick agent` | run reconciliation loop (`--once` for a single pass) |
 | `tailstick cleanup` | force cleanup for one lease id |
 | `tailstick version` | print version |
+
+### `run` flags
+
+| flag | default | description |
+| --- | --- | --- |
+| `--preset` | `""` | preset id from config |
+| `--mode` | `session` | lease mode: `session`, `timed`, or `permanent` |
+| `--channel` | `stable` | install channel: `stable` or `latest` |
+| `--days` | `3` | timed lease duration in days |
+| `--custom-days` | `0` | custom lease days (1–30, overrides `--days`) |
+| `--suffix` | `""` | optional device name suffix |
+| `--exit-node` | `""` | optional approved exit node |
+| `--allow-existing` | `false` | allow existing tailscale install |
+| `--non-interactive` | `false` | non-interactive mode |
+| `--password` | `""` | operator password (or set `TAILSTICK_OPERATOR_PASSWORD`) |
+| `--config` | `tailstick.config.json` | config file path |
+| `--state` | platform default | state file path |
+| `--audit` | `logs/tailstick-audit.ndjson` | audit log path |
+| `--log` | platform default | log file path |
+| `--dry-run` | `false` | print commands without executing |
+
+### `agent` flags
+
+| flag | default | description |
+| --- | --- | --- |
+| `--once` | `false` | run one reconciliation pass and exit |
+| `--interval` | `1m` | reconciliation interval |
+
+the agent also accepts `--config`, `--state`, `--audit`, `--log`, and `--dry-run`.
+
+### `cleanup` flags
+
+| flag | default | description |
+| --- | --- | --- |
+| `--lease-id` | `""` | lease id to clean (required) |
+
+the cleanup command also accepts `--config`, `--state`, `--audit`, `--log`, and `--dry-run`.
+
+### gui flags
+
+the gui binary (`tailstick-linux-gui` / `tailstick-windows-gui`) starts a local browser-based setup wizard. in addition to the shared flags (`--config`, `--state`, `--audit`, `--log`, `--dry-run`):
+
+| flag | default | description |
+| --- | --- | --- |
+| `--host` | `127.0.0.1` | bind host |
+| `--port` | `0` | bind port (`0` picks an ephemeral port) |
+| `--open-browser` | `true` | open browser automatically |
+
+## lease modes
+
+| mode | behavior |
+| --- | --- |
+| `session` | cleaned after reboot/shutdown detection |
+| `timed` | cleaned when expiry is reached (set duration with `--days` or `--custom-days`) |
+| `permanent` | leaves normal tailscale install and no automatic cleanup |
 
 for lease modes, tailstick installs local scheduling:
 
@@ -58,13 +122,18 @@ the scheduled command runs from a machine-local binary copy:
 - linux: `/var/lib/tailstick/tailstick-agent`
 - windows: `%ProgramData%\TailStick\tailstick-agent.exe`
 
-## lease modes
+## environment variables
 
-| mode | behavior |
+secrets are resolved from environment variables. the config file supports `authKeyEnv`, `ephemeralAuthKeyEnv`, and `apiKeyEnv` fields that name the env var to read. common variables:
+
+| variable | purpose |
 | --- | --- |
-| `session` | cleaned after reboot/shutdown detection |
-| `timed` | cleaned when expiry is reached (`1`, `3`, `7`, or bounded custom days) |
-| `permanent` | leaves normal tailscale install and no automatic cleanup |
+| `TAILSTICK_AUTH_KEY` | tailscale auth key |
+| `TAILSTICK_EPHEMERAL_AUTH_KEY` | tailscale ephemeral auth key |
+| `TAILSTICK_API_KEY` | tailscale api key for cleanup |
+| `TAILSTICK_OPERATOR_PASSWORD` | operator password for gated presets |
+
+see `.env.example` for a template.
 
 ## examples
 
@@ -95,6 +164,33 @@ manual cleanup:
 ./tailstick-linux-cli cleanup --lease-id <lease-id>
 ```
 
+single agent pass:
+
+```bash
+./tailstick-linux-cli agent --once
+```
+
+## building from source
+
+```bash
+go build ./cmd/tailstick-linux-cli
+go build ./cmd/tailstick-linux-gui
+```
+
+cross-compile all targets:
+
+```bash
+make build-all
+```
+
+run tests:
+
+```bash
+go test ./...
+```
+
+see the `Makefile` for additional targets (`fmt`, `vet`, `sandbox-linux`, `icons`).
+
 ## documentation
 
 - [architecture](docs/architecture.md)
@@ -102,7 +198,7 @@ manual cleanup:
 - [operations](docs/operations.md)
 - [testing](docs/testing.md)
 - [release runbook](docs/release-runbook.md)
-- [plan](PLAN.md)
+- [contributing](CONTRIBUTING.md)
 
 ## license
 


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** readme-improvements
**Category:** pr
**Changes:**

1. **New "Requirements" section** — Documents elevated privileges (sudo on linux, admin on windows), debian/ubuntu + systemd requirement for linux, and Go 1.22+ for building.
2. **Complete CLI flag reference** — Added detailed flag tables for all 4 subcommands (`run`, `agent`, `cleanup`, `gui`) with flag names, defaults, and descriptions.
3. **New "Environment variables" section** — Documents the 4 common env vars and references `.env.example`.
4. **New "Building from source" section** — Documents `go build`, `make build-all`, `go test`, and Makefile targets.
5. **Fixed stale PLAN.md link** → replaced with `CONTRIBUTING.md` link.
6. **Fixed lease modes description** — Removed hardcoded "1, 3, 7" days, now references `--days` and `--custom-days` flags accurately.
7. **Added arm64 architecture info** — Release workflow builds for arm64 on both linux and windows.
8. **Added `agent --once` example** — A commonly needed operation that was missing.

Merge if useful, close if not.