### PR TITLE
[nightshift] dead-code: remove unused ResolvePath and RunWithTimeout

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/tailstick/tailstick/internal/model"
@@ -81,16 +80,6 @@ func FindPreset(cfg model.Config, id string) (model.Preset, error) {
 		}
 	}
 	return model.Preset{}, fmt.Errorf("preset %q not found", id)
-}
-
-func ResolvePath(baseDir, path string) string {
-	if path == "" {
-		return ""
-	}
-	if filepath.IsAbs(path) {
-		return path
-	}
-	return filepath.Join(baseDir, path)
 }
 
 func ResolvePresetSecrets(p model.Preset) model.Preset {

--- a/internal/platform/exec.go
+++ b/internal/platform/exec.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
-	"time"
 )
 
 type Runner struct {
@@ -32,10 +31,4 @@ func (r Runner) Run(ctx context.Context, args []string) (string, error) {
 		return out.String(), fmt.Errorf("%w: %s", err, strings.TrimSpace(out.String()))
 	}
 	return out.String(), nil
-}
-
-func (r Runner) RunWithTimeout(timeout time.Duration, args []string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	return r.Run(ctx, args)
 }


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** dead-code
**Category:** pr
**Changes:**
- Removed `config.ResolvePath()` — exported function never called from any file or test
- Removed `platform.RunWithTimeout()` — method on Runner never called from any file or test
- Cleaned up now-unused imports (`path/filepath` from config.go, `time` from exec.go)

The codebase is otherwise clean — no commented-out code blocks, unused imports, or unreachable code found.

Merge if useful, close if not.