### PR TITLE
[nightshift] api-contract-verify: fix GUI API contract issues

### DIFF
--- a/internal/gui/server.go
+++ b/internal/gui/server.go
@@ -155,6 +155,10 @@ func (s *Server) enroll(w http.ResponseWriter, r *http.Request) {
 		writeJSONCode(w, http.StatusBadRequest, map[string]any{"ok": false, "error": "customDays must be non-negative"})
 		return
 	}
+	if req.Mode == string(model.LeaseModeTimed) && req.CustomDays == 0 && req.Days == 0 {
+		writeJSONCode(w, http.StatusBadRequest, map[string]any{"ok": false, "error": "timed mode requires days > 0 or customDays > 0"})
+		return
+	}
 	password := strings.TrimSpace(req.Password)
 	if password == "" {
 		password = strings.TrimSpace(os.Getenv("TAILSTICK_OPERATOR_PASSWORD"))
@@ -174,13 +178,16 @@ func (s *Server) enroll(w http.ResponseWriter, r *http.Request) {
 		writeJSONCode(w, http.StatusBadRequest, map[string]any{"ok": false, "error": err.Error()})
 		return
 	}
-	writeJSON(w, map[string]any{
+	resp := map[string]any{
 		"ok":         true,
 		"leaseId":    rec.LeaseID,
 		"deviceName": rec.DeviceName,
 		"mode":       rec.Mode,
-		"expiresAt":  rec.ExpiresAt,
-	})
+	}
+	if rec.ExpiresAt != nil {
+		resp["expiresAt"] = rec.ExpiresAt
+	}
+	writeJSON(w, resp)
 }
 
 func (s *Server) index(w http.ResponseWriter, r *http.Request) {

--- a/internal/gui/server_test.go
+++ b/internal/gui/server_test.go
@@ -112,6 +112,11 @@ func TestEnrollRejectsInvalidModeAndNegativeDurations(t *testing.T) {
 			body: `{"mode":"timed","channel":"stable","customDays":-1}`,
 			want: `customDays must be non-negative`,
 		},
+		{
+			name: "timed mode with zero days",
+			body: `{"mode":"timed","channel":"stable","days":0}`,
+			want: `timed mode requires days > 0`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "/api/enroll", bytes.NewBufferString(tc.body))


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** api-contract-verify
**Category:** pr
**Changes:** Fix GUI API contract issues in `/api/enroll` endpoint

### Findings & Fixes

1. **`/api/enroll` response includes `null` for `expiresAt` on session/permanent leases** (Fixed)
   - The response used `map[string]any{"expiresAt": rec.ExpiresAt}` which serializes as `"expiresAt": null` for nil pointers, even though `LeaseRecord` uses `omitempty`.
   - Fix: Only include `expiresAt` in the response when it's non-nil.

2. **Missing validation for timed mode with zero days** (Fixed)
   - The GUI `/api/enroll` endpoint accepted `{"mode":"timed","days":0}` without error, deferring to `ParseDurationDays` which rejects it. However, the GUI should validate this early with a clear error message.
   - Fix: Added early validation before calling `EnrollFn`.
   - Added test case for the new validation.

3. **`presetSummary` omits `StableVersionOverride`** (Documented, not fixed)
   - The `/api/presets` response doesn't include `stableVersionOverride`. This is a minor contract gap — the frontend can't display whether a preset pins to a specific version. Not fixed as it requires frontend changes.

4. **`enrollRequest` doesn't map `NonInteractive`** (Documented, not fixed)
   - The GUI always runs in non-interactive mode by design. `NonInteractive` is not part of the request schema. This is correct behavior, documented for completeness.

Merge if useful, close if not.