### PR TITLE
[nightshift] ci-fixes: align Go version, add permissions, fix gofmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test-and-build:
     runs-on: ubuntu-latest
@@ -14,11 +17,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.25.6"
 
       - name: Verify formatting
         run: |
-          unformatted="$(gofmt -l $(find . -name '*.go' -type f))"
+          unformatted="$(gofmt -l .)"
           if [ -n "$unformatted" ]; then
             echo "Unformatted files:"
             echo "$unformatted"
@@ -47,7 +50,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.25.6"
 
       - name: Build Linux CLI binary
         run: |
@@ -68,7 +71,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.25.6"
 
       - name: Build Windows CLI binary
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.25.6"
 
       - name: Build artifacts
         run: |


### PR DESCRIPTION
## nightshift: ci-fixes

### Changes

**Go version alignment (critical)**
- `ci.yml` and `release.yml` used `go-version: "1.22"` while `go.mod` requires `go 1.25.6`
- `live-e2e.yml` already used the correct version — this was an inconsistency
- Updated all workflow files to use `go-version: "1.25.6"` to match `go.mod`

**Permissions hardening**
- Added `permissions: contents: read` to `ci.yml` for least-privilege principle
- Previous workflows had no explicit permissions block (used repo defaults)

**gofmt check fix**
- Changed `gofmt -l $(find . -name '*.go' -type f)` to `gofmt -l .`
- The find subshell can fail with "argument list too long" on large repos
- `gofmt -l .` handles this natively

### Files Changed
- `.github/workflows/ci.yml` — Go version, permissions, gofmt
- `.github/workflows/release.yml` — Go version

### Verification
- Go version now consistent across all 4 workflow files
- `permissions` block follows GitHub security best practices
- `gofmt -l .` is the idiomatic approach