### PR TITLE
fix: nightshift: dependency-risk — 2 findings (module path mismatch, Go version)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing. This guide covers the basics.
 
 ## Development Setup
 
-1. **Go 1.25.6+** is required.
+1. **Go 1.25.0+** is required.
 2. Clone the repository and build:
    ```bash
    go build ./...

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ if you need to get a field machine onto your tailnet without building a backend 
 - **elevated privileges** are required for enrollment and cleanup (`sudo` on linux, administrator on windows).
 - **linux**: debian or ubuntu with `systemd`. other distributions are not supported in the current release.
 - **windows**: standard windows with scheduled tasks available.
-- **go 1.25.6+** is required for building from source.
+- **go 1.25.0+** is required for building from source.
 
 ## quickstart
 

--- a/cmd/tailstick-linux-cli/main.go
+++ b/cmd/tailstick-linux-cli/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/tailstick/tailstick/internal/app"
+	"github.com/Microck/tailstick/internal/app"
 )
 
 func main() {

--- a/cmd/tailstick-linux-gui/main.go
+++ b/cmd/tailstick-linux-gui/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/tailstick/tailstick/internal/app"
+	"github.com/Microck/tailstick/internal/app"
 )
 
 func main() {

--- a/cmd/tailstick-windows-cli/main.go
+++ b/cmd/tailstick-windows-cli/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/tailstick/tailstick/internal/app"
+	"github.com/Microck/tailstick/internal/app"
 )
 
 func main() {

--- a/cmd/tailstick-windows-gui/main.go
+++ b/cmd/tailstick-windows-gui/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/tailstick/tailstick/internal/app"
+	"github.com/Microck/tailstick/internal/app"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/tailstick/tailstick
+module github.com/Microck/tailstick
 
-go 1.25.6
+go 1.25.0
 
 require golang.org/x/crypto v0.49.0

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/tailstick/tailstick/internal/model"
+	"github.com/Microck/tailstick/internal/model"
 )
 
 const Version = "1.0.0"

--- a/internal/app/gui.go
+++ b/internal/app/gui.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/tailstick/tailstick/internal/gui"
+	"github.com/Microck/tailstick/internal/gui"
 )
 
 func RunGUI(args []string, rt Runtime) int {

--- a/internal/app/workflow.go
+++ b/internal/app/workflow.go
@@ -17,13 +17,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tailstick/tailstick/internal/config"
-	intcrypto "github.com/tailstick/tailstick/internal/crypto"
-	"github.com/tailstick/tailstick/internal/logging"
-	"github.com/tailstick/tailstick/internal/model"
-	"github.com/tailstick/tailstick/internal/platform"
-	"github.com/tailstick/tailstick/internal/state"
-	"github.com/tailstick/tailstick/internal/tailscale"
+	"github.com/Microck/tailstick/internal/config"
+	intcrypto "github.com/Microck/tailstick/internal/crypto"
+	"github.com/Microck/tailstick/internal/logging"
+	"github.com/Microck/tailstick/internal/model"
+	"github.com/Microck/tailstick/internal/platform"
+	"github.com/Microck/tailstick/internal/state"
+	"github.com/Microck/tailstick/internal/tailscale"
 )
 
 type Runtime struct {

--- a/internal/app/workflow_test.go
+++ b/internal/app/workflow_test.go
@@ -12,12 +12,12 @@ import (
 	"testing"
 	"time"
 
-	intcrypto "github.com/tailstick/tailstick/internal/crypto"
-	"github.com/tailstick/tailstick/internal/logging"
-	"github.com/tailstick/tailstick/internal/model"
-	"github.com/tailstick/tailstick/internal/platform"
-	"github.com/tailstick/tailstick/internal/state"
-	"github.com/tailstick/tailstick/internal/tailscale"
+	intcrypto "github.com/Microck/tailstick/internal/crypto"
+	"github.com/Microck/tailstick/internal/logging"
+	"github.com/Microck/tailstick/internal/model"
+	"github.com/Microck/tailstick/internal/platform"
+	"github.com/Microck/tailstick/internal/state"
+	"github.com/Microck/tailstick/internal/tailscale"
 )
 
 func TestBuildDeviceName(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/tailstick/tailstick/internal/model"
+	"github.com/Microck/tailstick/internal/model"
 )
 
 const (

--- a/internal/gui/server.go
+++ b/internal/gui/server.go
@@ -18,8 +18,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tailstick/tailstick/internal/config"
-	"github.com/tailstick/tailstick/internal/model"
+	"github.com/Microck/tailstick/internal/config"
+	"github.com/Microck/tailstick/internal/model"
 )
 
 //go:embed index.html tailstick-favicon.png

--- a/internal/gui/server_test.go
+++ b/internal/gui/server_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tailstick/tailstick/internal/model"
+	"github.com/Microck/tailstick/internal/model"
 )
 
 func TestPresetsRedactsSecretsAndOnlyAllowsGet(t *testing.T) {

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/tailstick/tailstick/internal/model"
+	"github.com/Microck/tailstick/internal/model"
 )
 
 func Load(path string) (model.LocalState, error) {

--- a/internal/tailscale/client.go
+++ b/internal/tailscale/client.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tailstick/tailstick/internal/model"
-	"github.com/tailstick/tailstick/internal/platform"
+	"github.com/Microck/tailstick/internal/model"
+	"github.com/Microck/tailstick/internal/platform"
 )
 
 type Client struct {

--- a/internal/tailscale/client_test.go
+++ b/internal/tailscale/client_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tailstick/tailstick/internal/model"
-	"github.com/tailstick/tailstick/internal/platform"
+	"github.com/Microck/tailstick/internal/model"
+	"github.com/Microck/tailstick/internal/platform"
 )
 
 func TestDeleteDeviceTreatsNotFoundAsAlreadyDeleted(t *testing.T) {


### PR DESCRIPTION
<!-- revisor:issue=https://github.com/Microck/tailstick/issues/46 branch=revisor/issue-46-nightshift-dependency-risk-2-findings-module-pat -->

Fixes https://github.com/Microck/tailstick/issues/46

Generated by Revisor using the user's installed Codex CLI.
